### PR TITLE
Allow update suppression to be configurable

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -6,11 +6,7 @@ module MultipleMan
       base.extend(ClassMethods)
       if base.respond_to?(:after_commit)
         base.after_commit(on: :create) { |r| r.multiple_man_publish(:create) }
-        base.after_commit(on: :update) do |r|
-          if !r.respond_to?(:previous_changes) || r.previous_changes.any?
-            r.multiple_man_publish(:update)
-          end
-        end
+        base.after_commit(on: :update) { |r| r.multiple_man_publish(:update) }
         base.after_commit(on: :destroy) { |r| r.multiple_man_publish(:destroy) }
       end
 


### PR DESCRIPTION
Currently updates will be suppressed if the model
responds to #previous_changes and return an #empty?
object. This allows each publisher to specify an
:update_unless proc that will accept the record
being processed.