### PR TITLE
log consumer errors

### DIFF
--- a/lib/multiple_man/consumers/general.rb
+++ b/lib/multiple_man/consumers/general.rb
@@ -42,7 +42,7 @@ module MultipleMan
         begin
           raise ConsumerError
         rescue => wrapped_ex
-          MultipleMan.logger.debug "\tError #{wrapped_ex.message} \n#{wrapped_ex.backtrace}"
+          MultipleMan.logger.debug "\t#{wrapped_ex.class} #{wrapped_ex.cause.message} \n#{wrapped_ex.cause.backtrace}"
           MultipleMan.error(wrapped_ex, reraise: false, payload: message, delivery_info: delivery_info)
           queue.channel.nack(delivery_info.delivery_tag)
         end

--- a/spec/consumers/general_spec.rb
+++ b/spec/consumers/general_spec.rb
@@ -89,17 +89,22 @@ describe MultipleMan::Consumers::General do
 
   it 'wraps errors in ConsumerError' do
     channel = double(Bunny::Channel)
-    queue = double(Bunny::Queue, channel: channel).as_null_object
+    queue   = double(Bunny::Queue, channel: channel).as_null_object
+    error   = ArgumentError.new("undefined method `foo' for nil:NilClass")
+    error.set_backtrace(["file.rb:1 'foo'"])
 
     delivery_info = OpenStruct.new(routing_key: "multiple_man.SomeClass.create")
     payload = '{"a":1,"b":2}'
     allow(queue).to receive(:subscribe).and_yield(delivery_info, double(:meta), payload)
 
     subscriber = listener1.new
-    allow(subscriber).to receive(:create).and_raise('anything')
+    allow(subscriber).to receive(:create).and_raise(error)
 
     allow(channel).to receive(:nack)
 
+    expect(MultipleMan.logger).to receive(:debug).with('Starting listeners.')
+    expect(MultipleMan.logger).to receive(:debug).with('Processing message for multiple_man.SomeClass.create.')
+    expect(MultipleMan.logger).to receive(:debug).with("\tMultipleMan::ConsumerError #{error.message} \n#{error.backtrace}")
     expect(MultipleMan).to receive(:error).with(kind_of(MultipleMan::ConsumerError), kind_of(Hash))
     subject = described_class.new(subscribers:[subscriber], queue: queue, topic: 'some-topic')
     subject.listen


### PR DESCRIPTION
* consumer are swallowing all exceptions and raising a new
  error, this new error message/backtrace are missing useful
  debugging information. printing out info from previous error
  makes diagnosing errors much quicker

Test logs of same error before and after logging change:

before
```
Error MultipleMan::ConsumerError
["lib/multiple_man/consumers/general.rb:43:in `rescue in receive'",
"lib/multiple_man/consumers/general.rb:36:in `receive'",
"lib/multiple_man/consumers/general.rb:20:in `block in listen'"
...]
```
after
```
MultipleMan::ConsumerError PG::NotNullViolation: ERROR:
null value in column "user_id" violates not-null constraint
DETAIL:  Failing row contains (null, some_user@influitive.com, some_name)

["lib/hanami/repository.rb:302:in `rescue in create'",
"lib/hanami/repository.rb:300:in `create'",
"my_app/user_repository.rb:20:in `create_user'",
"my_app/user_repository.rb:7:in `upsert'"
...]
```