### PR TITLE
fixed bug causing channels to leak

### DIFF
--- a/lib/multiple_man/channel_maintenance/reaper.rb
+++ b/lib/multiple_man/channel_maintenance/reaper.rb
@@ -9,9 +9,9 @@ module MultipleMan
           loop do
             channel = queue.pop
             begin
-              channel.close unless closed?
+              channel.close unless channel.closed?
               puts "Channel #{channel.number} closed!"
-            rescue Exception
+            rescue Bunny::Exception, Timeout::Error
               sleep config.connection_recovery[:time_between_retries]
               retry
             end

--- a/spec/channel_maintenance/reaper_spec.rb
+++ b/spec/channel_maintenance/reaper_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe MultipleMan::ChannelMaintenance::Reaper do
+  let(:mock_channel) { double(Bunny::Channel, close: nil, closed?: false, number: 1) }
+  let(:mock_queue) { double(Queue, pop: mock_channel) }
+  let(:mock_config_hash) { { time_between_retries: 1 } }
+  let(:mock_mm_config) { double(MultipleMan, connection_recovery: mock_config_hash) }
+
+  before do
+    expect(Queue).to receive(:new).and_return(mock_queue)
+    expect(Thread).to receive(:new).and_yield
+    expect_any_instance_of(
+      MultipleMan::ChannelMaintenance::Reaper
+    ).to receive(:loop).and_yield
+  end
+
+  it "reaps an open connection" do
+    expect(mock_channel).to receive(:close)
+
+    described_class.new(mock_mm_config)
+  end
+
+  it "raises errors" do
+    expect(mock_channel).to receive(:closed?).and_raise(NoMethodError)
+
+    expect { described_class.new(mock_mm_config) }.to raise_error(NoMethodError)
+  end
+end


### PR DESCRIPTION
 * MM is failing to cleanup unused channels, causing
 a steady leak
 * Reaper is catching a NoMethodError off a typo and never
 closing the channels. This should only catch Bunny related
 exceptions (http://rubybunny.info/articles/error_handling.html)

script to reproduce below. This will open 100 channels
then stop using them, looking at a rabbitmq management
console, all 100 will remain open and idle until the
connection is closed by the script exiting:

```

require 'multiple_man'

MultipleMan.configure do |config|
   rabbit_opts = AMQ::Settings.parse_amqp_url('amqp://guest:guest@10.0.2.2:5672')
   rabbit_opts[:hosts] = rabbit_opts.delete(:host).split(',')
   config.connection = rabbit_opts
   config.topic_name = "threadtest"
   config.app_name = 'ThreadTest'
   config.logger = Logger.new($stdout)
end

100.times do
   Thread.new do
     MultipleMan::Connection.channel
     sleep 1 # wait for channel to open
     Thread.exit
  end
end
```