### PR TITLE
fix issue where mm listener hangs forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,26 +190,6 @@ MyModel.multiple_man_publish(:seed)
 
 3. Stop the seeder rake task when all of your messages have been processed. You can check your RabbitMQ server
 
-## Upgrading to 1.0
-
-The major change is that MultipleMan will no longer create a queue per listener.
-There is only 1 queue that will have multiple bindings to the exchange so that
-you have a chance to maintain causal consistency.
-
-Assuming you are using vanilla MultipleMan you will need to run both the
-regular worker and the new 'transition_worker' for a short period. The
-transitional worker will connect to your old queues, unbind them and allow them
-to drain. Once the queues are empty you can safely shut the transitional worker
-down and delete the old queues.
-
-So for example if you use a Procfile:
-
-```
-multiple_man_worker: rake multiple_man:worker
-# Temporary until old queues are drained
-transition_worker: rake multiple_man:transition_worker
-```
-
 ## Contributing
 
 1. Fork it

--- a/lib/multiple_man/consumers/general.rb
+++ b/lib/multiple_man/consumers/general.rb
@@ -14,7 +14,7 @@ module MultipleMan
         MultipleMan.logger.debug "Starting listeners."
         create_bindings
 
-        queue.subscribe(manual_ack: true) do |delivery_info, meta_data, payload|
+        queue.subscribe(block: true, manual_ack: true) do |delivery_info, meta_data, payload|
           MultipleMan.logger.debug "Processing message for #{delivery_info.routing_key}."
           message = JSON.parse(payload).with_indifferent_access
           receive(delivery_info, meta_data, message)

--- a/lib/multiple_man/runner.rb
+++ b/lib/multiple_man/runner.rb
@@ -1,19 +1,6 @@
 require 'forwardable'
 
 module MultipleMan
-  def self.trap_signals!
-    return if @signals_trapped
-
-    @signals_trapped = true
-
-    handler = proc do |signal|
-      puts "received #{Signal.signame(signal)}"
-      exit
-    end
-
-    %w(INT QUIT TERM).each { |signal| Signal.trap(signal, handler) }
-  end
-
   class Runner
     extend Forwardable
 
@@ -26,11 +13,9 @@ module MultipleMan
     end
 
     def run
-      MultipleMan.trap_signals!
       preload_framework!
       channel.prefetch(prefetch_size)
       build_listener.listen
-      sleep
     end
 
     private

--- a/lib/multiple_man/tasks/worker.rake
+++ b/lib/multiple_man/tasks/worker.rake
@@ -8,29 +8,4 @@ namespace :multiple_man do
   task seed: :environment do
     MultipleMan::Runner.new(mode: :seed).run
   end
-
-  desc 'Run transitional worker'
-  task transition_worker: :environment do
-    Rails.application.eager_load! if defined?(Rails)
-
-    topic = MultipleMan.configuration.topic_name
-    app_name = MultipleMan.configuration.app_name
-    channel = MultipleMan::Connection.connection.create_channel
-    channel.prefetch(MultipleMan.configuration.prefetch_size)
-
-    MultipleMan.configuration.listeners.each do |listener|
-      queue_name = listener.respond_to?(:queue_name) ?
-                     listener.queue_name :
-                     "#{topic}.#{app_name}.#{listener.listen_to}"
-
-      next unless MultipleMan::Connection.connection.queue_exists?(queue_name)
-      queue = channel.queue(queue_name, durable: true, auto_delete: false)
-
-      MultipleMan::Consumers::Transitional.new(subscription: listener, queue: queue, topic: topic).listen
-    end
-
-    MultipleMan.trap_signals!
-    sleep
-  end
-
 end

--- a/spec/consumers/general_spec.rb
+++ b/spec/consumers/general_spec.rb
@@ -29,7 +29,7 @@ describe MultipleMan::Consumers::General do
 
     expect(queue).to receive(:bind).with('some-topic', routing_key: subscriptions.first.routing_key).ordered
     expect(queue).to receive(:bind).with('some-topic', routing_key: subscriptions.last.routing_key).ordered
-    expect(queue).to receive(:subscribe).with(manual_ack: true).ordered
+    expect(queue).to receive(:subscribe).with(block: true, manual_ack: true).ordered
 
     subject = described_class.new(subscribers: subscriptions, queue: queue, topic: 'some-topic')
 

--- a/spec/consumers/seed_spec.rb
+++ b/spec/consumers/seed_spec.rb
@@ -17,7 +17,7 @@ describe MultipleMan::Consumers::Seed do
     queue = double(Bunny::Queue, channel: channel)
 
     expect(queue).to receive(:bind).with('some-topic', routing_key: "multiple_man.seed.SomeClass")
-    expect(queue).to receive(:subscribe).with(manual_ack: true)
+    expect(queue).to receive(:subscribe).with(block: true, manual_ack: true)
 
     subject = described_class.new(subscribers: [listener1.new], queue: queue, topic: 'some-topic')
     subject.listen

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe MultipleMan::Runner do
+  let(:mock_channel) { double("Channel", prefetch: true, queue: true) }
+  let(:mock_connection) { double("Connection", create_channel: mock_channel) }
+  let(:mock_consumer) { double("Consumer", listen: true) }
+
+  it 'boots app and listens on new channel' do
+    expect(MultipleMan::Connection).to receive(:connection).and_return(mock_connection)
+    expect(MultipleMan::Consumers::General).to receive(:new).and_return(mock_consumer)
+
+    expect(mock_consumer).to receive(:listen)
+
+    runner = described_class.new(mode: :general)
+    runner.run
+  end
+end


### PR DESCRIPTION
 * when the consumer failed (bunny consumer block dies) the mm
 listener would block on `sleep`, and stop consuming without
 any notifications. `block: true` consumer option is designed
 for this: http://rubybunny.info/articles/queues.html
 * removing trap signals because it is confusing and I can't see
 what purpose it serves

to reproduce:
 * start a listener with `bundle exec rake multiple_man:worker`
 * restart or force stop rabbitmq
 * listener will be running, but the bunny consumer will no
 longer be running
 * try sending a message