### PR TITLE
add publisher confirms

### DIFF
--- a/lib/multiple_man.rb
+++ b/lib/multiple_man.rb
@@ -4,6 +4,8 @@ require 'active_support'
 module MultipleMan
   Error = Class.new(StandardError)
   ConsumerError = Class.new(Error)
+  ProducerError = Class.new(Error)
+  ConnectionError = Class.new(Error)
 
   require 'multiple_man/railtie' if defined?(Rails)
 

--- a/lib/multiple_man/configuration.rb
+++ b/lib/multiple_man/configuration.rb
@@ -11,7 +11,8 @@ module MultipleMan
     attr_reader :subscriber_registry
     attr_accessor :topic_name, :app_name, :connection, :enabled, :error_handler,
                   :worker_concurrency, :reraise_errors, :connection_recovery,
-                  :queue_name, :prefetch_size, :bunny_opts, :exchange_opts
+                  :queue_name, :prefetch_size, :bunny_opts, :exchange_opts,
+                  :publisher_confirms
 
     attr_writer :logger
 
@@ -29,6 +30,7 @@ module MultipleMan
       }
       self.bunny_opts = {}
       self.exchange_opts = {}
+      self.publisher_confirms = false
 
       @subscriber_registry = Subscribers::Registry.new
     end

--- a/lib/multiple_man/connection.rb
+++ b/lib/multiple_man/connection.rb
@@ -21,13 +21,14 @@ module MultipleMan
         retry
       else
         Thread.current[:multiple_man_exception_retry_count] = 0
-        raise "MultipleMan::ConnectionError"
+        raise ConnectionError, e
       end
     end
 
     def self.channel
       Thread.current.thread_variable_get(:multiple_man_current_channel) || begin
         channel = connection.create_channel
+        channel.confirm_select if MultipleMan.configuration.publisher_confirms
         channel_gc.push(channel)
         Thread.current.thread_variable_set(:multiple_man_current_channel, channel)
 

--- a/spec/model_publisher_spec.rb
+++ b/spec/model_publisher_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MultipleMan::ModelPublisher do 
+describe MultipleMan::ModelPublisher do
   let(:channel_stub) { double(Bunny::Channel, topic: topic_stub)}
   let(:topic_stub) { double(Bunny::Exchange, publish: nil) }
 
@@ -35,10 +35,17 @@ describe MultipleMan::ModelPublisher do
     end
 
     it "should call the error handler on error" do
-      ex = Exception.new("Bad stuff happened")
+      records    = MockObject.new
+      mock_error = MultipleMan::ProducerError.new
+      ex         = Exception.new("Bad stuff happened")
+
       topic_stub.stub(:publish) { raise ex }
-      MultipleMan.should_receive(:error).with(ex)
-      described_class.new(fields: [:foo]).publish(MockObject.new)
+      MultipleMan.should_receive(:error).with(mock_error, reraise: false)
+      MultipleMan::ProducerError.should_receive(
+        :new
+      ).with(reason: ex, payload: records.inspect).and_return(mock_error)
+
+      described_class.new(fields: [:foo]).publish(records)
     end
   end
 
@@ -59,5 +66,4 @@ describe MultipleMan::ModelPublisher do
       subject.publish(obj)
     end
   end
-
 end


### PR DESCRIPTION
* `config.publisher_confirms = true`, defaults false
* `MultipleMan::ConnectionError` is now a class, instead of
a RunTimeError with connection error as the message
* producer now raises `ProducerError` when producing fails,
will also raise this when publisher confirms fail