### PR TITLE
Adding `after_touch` callback to `MultipleMan::Publisher`.

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -12,6 +12,7 @@ module MultipleMan
           end
         end
         base.after_commit(on: :destroy) { |r| r.multiple_man_publish(:destroy) }
+        base.after_touch { |r| r.multiple_man_publish(:update) }
       end
 
       base.class_attribute :multiple_man_publisher

--- a/spec/mixins/publisher_spec.rb
+++ b/spec/mixins/publisher_spec.rb
@@ -8,6 +8,9 @@ describe MultipleMan::Publisher do
       def after_commit(subscriber)
         self.subscriber = subscriber
       end
+
+      def after_touch
+      end
     end
 
     include MultipleMan::Publisher


### PR DESCRIPTION
Treats `#touch` as an intentional publish trigger. This allows for republishing by touching individual models directly:

```ruby
widget.touch
```

And models associated via `belongs_to`:

```ruby
class Widget < ActiveRecord::Base
  ...
  belongs_to :group, touch: true
end

class Group < ActiveRecord::Base
  ...
  has_many :widgets
end

widget = Widget.find(...)
widget.name = 'foo'
widget.save # Also touches corresponding Group, triggering publish.
```