### PR TITLE
Add Tracing Middleware for custom subscriber instrumentation

### DIFF
--- a/lib/multiple_man.rb
+++ b/lib/multiple_man.rb
@@ -15,6 +15,7 @@ module MultipleMan
   require 'multiple_man/subscribers/base'
   require 'multiple_man/subscribers/model_subscriber'
   require 'multiple_man/subscribers/registry'
+  require 'multiple_man/tracers/null_tracer'
   require 'multiple_man/configuration'
   require 'multiple_man/model_publisher'
   require 'multiple_man/attribute_extractor'

--- a/lib/multiple_man/configuration.rb
+++ b/lib/multiple_man/configuration.rb
@@ -14,7 +14,7 @@ module MultipleMan
                   :queue_name, :prefetch_size, :bunny_opts, :exchange_opts,
                   :publisher_confirms
 
-    attr_writer :logger
+    attr_writer :logger, :tracer
 
     def initialize
       self.topic_name = "multiple_man"
@@ -41,6 +41,10 @@ module MultipleMan
 
     def logger
       @logger ||= defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
+    end
+
+    def tracer
+      @tracer ||= ::MultipleMan::Tracers::NullTracer
     end
 
     def on_error(&block)

--- a/lib/multiple_man/tracers/null_tracer.rb
+++ b/lib/multiple_man/tracers/null_tracer.rb
@@ -1,0 +1,13 @@
+module MultipleMan
+  module Tracers
+    class NullTracer
+      def initialize(subscriber)
+        @subscriber = subscriber
+      end
+
+      def handle(delivery_info, meta_data, message, method)
+        @subscriber.send(method, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows us to add Instrumentation at the MultipleMan level with more information than what is provided currently on the endpoint (delivery_info, meta_data, ...).

The default behaviour is unchanged, via use of the NullTracer object.

Some cleanup was also done to pass all details down within the Generic Consumer code.