### PR TITLE
 outbox: add db management

### DIFF
--- a/bin/multiple_man_db_migrate
+++ b/bin/multiple_man_db_migrate
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'uri'
+require "multiple_man"
+require 'multiple_man/outbox/db'
+
+db_url = ARGV[0]
+
+fail "provide a valid database url: #{db_url}" unless db_url && db_url =~ URI.regexp
+
+MultipleMan::Outbox::DB.run_migrations(db_url: db_url)
+
+puts "migrated successfully: #{db_url}"

--- a/lib/multiple_man/configuration.rb
+++ b/lib/multiple_man/configuration.rb
@@ -12,7 +12,7 @@ module MultipleMan
     attr_accessor :topic_name, :app_name, :connection, :enabled, :error_handler,
                   :worker_concurrency, :reraise_errors, :connection_recovery,
                   :queue_name, :prefetch_size, :bunny_opts, :exchange_opts,
-                  :publisher_confirms
+                  :publisher_confirms, :messaging_mode, :db_url, :alpha_topic_name
 
     attr_writer :logger, :tracer
 
@@ -31,6 +31,8 @@ module MultipleMan
       self.bunny_opts = {}
       self.exchange_opts = {}
       self.publisher_confirms = false
+      self.messaging_mode = :at_most_once
+      self.db_url = nil
 
       @subscriber_registry = Subscribers::Registry.new
     end

--- a/lib/multiple_man/outbox/adapters/general.rb
+++ b/lib/multiple_man/outbox/adapters/general.rb
@@ -1,0 +1,8 @@
+module MultipleMan
+  module Outbox
+    module Adapters
+      class General < ::Sequel::Model(Outbox::DB.connection[:multiple_man_messages])
+      end
+    end
+  end
+end

--- a/lib/multiple_man/outbox/db.rb
+++ b/lib/multiple_man/outbox/db.rb
@@ -1,0 +1,29 @@
+require 'sequel'
+
+extensions = %i[
+  migration
+]
+
+extensions.each { |ext| Sequel.extension(ext) }
+
+module MultipleMan
+  module Outbox
+    module DB
+      module_function
+
+      def connection
+        @connection ||= begin
+          Sequel.connect(MultipleMan.configuration.db_url)
+        end
+      end
+
+      def run_migrations(db_url: MultipleMan.configuration.db_url)
+        Sequel.connect(db_url) do |db|
+          db.logger = MultipleMan.configuration.logger
+          dir = File.join(__dir__, 'migrations')
+          Sequel::TimestampMigrator.run(db, dir, table: :multiple_man_schema_info)
+        end
+      end
+    end
+  end
+end

--- a/lib/multiple_man/outbox/migrations/20180116141230_create_messages.rb
+++ b/lib/multiple_man/outbox/migrations/20180116141230_create_messages.rb
@@ -1,0 +1,14 @@
+Sequel.migration do
+  change do
+    create_table :multiple_man_messages do
+      primary_key :id, 'BIGSERIAL'
+      column :routing_key, String, null: false
+      column :payload, String, null: false
+
+      column :created_at, Time, null: false
+      column :updated_at, Time, null: false
+
+      index :id
+    end
+  end
+end

--- a/multiple_man.gemspec
+++ b/multiple_man.gemspec
@@ -14,13 +14,15 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = ['multiple_man', 'multiple_man_db_migrate']
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.1'
 
   spec.add_runtime_dependency     "bunny", '>= 1.2'
   spec.add_runtime_dependency     "activesupport", '>= 3.0'
+  spec.add_runtime_dependency     "pg", '~> 0.18'
+  spec.add_runtime_dependency     'sequel'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry"

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -16,6 +16,7 @@ describe MultipleMan::Connection do
     MultipleMan::Connection.should_receive(:connection).and_return(mock_bunny)
     mock_bunny.should_receive(:create_channel).once.and_return(mock_channel)
     expect(mock_channel).to receive(:topic).with(MultipleMan.configuration.topic_name, durable: true, another: 'opt')
+    expect(mock_channel).to receive(:confirm_select)
 
     described_class.connect { }
   end

--- a/spec/outbox/adapters/general_spec.rb
+++ b/spec/outbox/adapters/general_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'Outbox::Adapters::General' do
+  before(:each) do
+    setup_db
+  end
+
+  after(:each) do
+    clear_db
+  end
+
+  let(:subject) { MultipleMan::Outbox::Adapters::General }
+
+  it 'can create/delete message' do
+    create_messages(1)
+
+    expect(subject.all.count).to eq(1)
+
+    subject.last.delete
+
+    expect(subject.all.count).to eq(0)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,57 @@ require 'ostruct'
 require 'pry'
 
 require_relative '../lib/multiple_man.rb'
+
+def configure_multiple_man
+  MultipleMan.configure do |config|
+    config.exchange_opts             = { durable: true }
+    config.logger.level              = 'FATAL' # null logger
+    config.publisher_confirms        = true
+    config.app_name                  = 'test_suite'
+    MultipleMan.configuration.db_url = 'postgresql://0.0.0.0:5432/postgres'
+  end
+end
+configure_multiple_man
+
+def setup_db
+  require 'multiple_man/outbox/db'
+
+  db.run_migrations
+end
+
+def create_messages(count)
+  require_relative '../lib/multiple_man/outbox/adapters/general'
+
+  count.times do |i|
+    message = sample_message(i)
+    MultipleMan::Outbox::Adapters::General.insert(message)
+  end
+end
+
+def routing_keys
+  listener_klasses = 3.times.map { |i| "User#{i}" }
+
+  @routing_key ||= listener_klasses.map do |klass|
+    "multiple_man.#{klass}.create"
+  end
+end
+
+def sample_message(i)
+  message = {
+    routing_key: routing_keys.sample,
+    payload:     { counter: i }.to_json,
+    created_at:  Time.now,
+    updated_at:  Time.now
+  }
+end
+
+def db
+  require 'multiple_man/outbox/db'
+
+  MultipleMan::Outbox::DB
+end
+
+def clear_db
+  db.connection.drop_table :multiple_man_schema_info
+  db.connection.drop_table :multiple_man_messages
+end


### PR DESCRIPTION
 * not included at runtime

 * outbox needs a message table

 * migration script can be run with `bundle exec multiple_man_db_migrate postgresql://postgres:pw@postgres/my_app`

* added default mm config for test suite