### PR TITLE
directly call publish

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -17,8 +17,23 @@ module MultipleMan
       base.class_attribute :multiple_man_publisher
     end
 
-    def multiple_man_publish(operation=:create, outbox: false)
-      self.class.multiple_man_publisher.publish(self, operation, outbox: outbox)
+    def multiple_man_publish(operation=:create)
+      if MultipleMan.configuration.outbox_alpha?
+        multiple_man_publish_outbox_false(operation)
+        multiple_man_publish_outbox_true(operation)
+      elsif MultipleMan.configuration.at_least_once?
+        multiple_man_publish_outbox_true(operation)
+      else
+        multiple_man_publish_outbox_false(operation)
+      end
+    end
+
+    def multiple_man_publish_outbox_false(operation)
+      self.class.multiple_man_publisher.publish(self, operation, outbox: false)
+    end
+
+    def multiple_man_publish_outbox_true(operation)
+      self.class.multiple_man_publisher.publish(self, operation, outbox: true)
     end
 
     private
@@ -27,29 +42,29 @@ module MultipleMan
       if base.respond_to?(:after_update)
         base.after_update do |r|
           if r.respond_to?(:changed?) && r.changed?
-            r.multiple_man_publish(:update, outbox: true)
+            r.multiple_man_publish_outbox_true(:update)
           end
         end
       end
 
       if base.respond_to?(:before_destroy)
-        base.before_destroy { |r| r.multiple_man_publish(:destroy, outbox: true) }
+        base.before_destroy { |r| r.multiple_man_publish_outbox_true(:destroy) }
       end
 
       if base.respond_to?(:after_create)
-        base.after_create { |r| r.multiple_man_publish(:create, outbox: true) }
+        base.after_create { |r| r.multiple_man_publish_outbox_true(:create) }
       end
     end
 
     def self.add_post_commit_hooks(base)
       if base.respond_to?(:after_commit)
-        base.after_commit(on: :create) { |r| r.multiple_man_publish(:create) }
+        base.after_commit(on: :create) { |r| r.multiple_man_publish_outbox_false(:create) }
         base.after_commit(on: :update) do |r|
           if !r.respond_to?(:previous_changes) || r.previous_changes.any?
-            r.multiple_man_publish(:update)
+            r.multiple_man_publish_outbox_false(:update)
           end
         end
-        base.after_commit(on: :destroy) { |r| r.multiple_man_publish(:destroy) }
+        base.after_commit(on: :destroy) { |r| r.multiple_man_publish_outbox_false(:destroy) }
       end
     end
 

--- a/spec/integration/rails_publish_spec.rb
+++ b/spec/integration/rails_publish_spec.rb
@@ -42,6 +42,14 @@ describe "publishing at least once" do
       expect(payload).to eq(expeted_payload)
     end
 
+    it 'publishes payload when calling multiple_man_publish directly' do
+      user = MMTestUser.create!(name: name)
+      expect(MultipleMan::Outbox.count).to eq(1)
+
+      expect{user.multiple_man_publish}
+        .to change{MultipleMan::Outbox.count}.by(1)
+    end
+
     it 'publishes payload for CUD' do
       user = MMTestUser.create!(name: name)
       user.name = SecureRandom.uuid
@@ -100,6 +108,14 @@ describe "publishing at least once" do
 
       expect(MMTestUser.count).to eq(1)
     end
+
+    it 'publishes to outbox when calling multiple_man_publish directly' do
+      user = MMTestUser.create!(name: 'name')
+      expect(MultipleMan::Outbox.count).to eq(0)
+
+      expect{user.multiple_man_publish}
+        .to change{MultipleMan::Outbox.count}.by(0)
+    end
   end
 
   context 'outbox alpha' do
@@ -133,6 +149,14 @@ describe "publishing at least once" do
 
       routing_key = MultipleMan::Outbox::Message::Rails.last.routing_key
       expect(routing_key).to eq('multiple_man.MMTestUser.create')
+    end
+
+    it 'publishes payload when calling multiple_man_publish directly' do
+      user = MMTestUser.create!(name: 'name')
+      expect(MultipleMan::Outbox.count).to eq(1)
+
+      expect{user.multiple_man_publish}
+        .to change{MultipleMan::Outbox.count}.by(1)
     end
   end
 end

--- a/spec/mixins/publisher_spec.rb
+++ b/spec/mixins/publisher_spec.rb
@@ -25,14 +25,54 @@ describe MultipleMan::Publisher do
     end
   end
 
-  describe "publish" do
-    before { MockClass.publish }
+  describe "publish at most once" do
+    before {
+      MultipleMan.configuration.messaging_mode = :at_most_once
+      MockClass.publish
+    }
+
     it "should tell ModelPublisher to publish" do
       my_mock = MockClass.new
       mock_publisher = double(MultipleMan::ModelPublisher)
       MultipleMan::ModelPublisher.any_instance
                                  .should_receive(:publish)
                                  .with(my_mock, :create, { outbox: false })
+      my_mock.save
+    end
+  end
+
+  describe "publish at least once" do
+    before {
+      MultipleMan.configuration.messaging_mode = :at_least_once
+      MockClass.publish
+    }
+
+    it "should tell ModelPublisher to publish" do
+      my_mock = MockClass.new
+      mock_publisher = double(MultipleMan::ModelPublisher)
+      MultipleMan::ModelPublisher.any_instance
+                                 .should_receive(:publish)
+                                 .with(my_mock, :create, { outbox: true })
+      my_mock.save
+    end
+  end
+
+  describe "publish twice" do
+    before {
+      MultipleMan.configuration.messaging_mode = :outbox_alpha
+      MockClass.publish
+    }
+
+    it "should tell ModelPublisher to publish" do
+      my_mock = MockClass.new
+      mock_publisher = double(MultipleMan::ModelPublisher)
+      MultipleMan::ModelPublisher.any_instance
+                                 .should_receive(:publish)
+                                 .with(my_mock, :create, { outbox: false })
+
+      MultipleMan::ModelPublisher.any_instance
+                                 .should_receive(:publish)
+                                 .with(my_mock, :create, { outbox: true })
       my_mock.save
     end
   end


### PR DESCRIPTION
calling `multiple_man_publish` needs to know what
messaging modes have been set and publish accordingly

covers the case where we have `outbox_alpha = true`, and
calling `record.multiple_man_publish` does not write to outbox