### PR TITLE
add after touch callback

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -54,6 +54,10 @@ module MultipleMan
       if base.respond_to?(:after_create)
         base.after_create { |r| r.multiple_man_publish_outbox_true(:create) }
       end
+
+      if base.respond_to?(:after_touch)
+        base.after_touch { |r| r.multiple_man_publish_outbox_true(:update) }
+      end
     end
 
     def self.add_post_commit_hooks(base)

--- a/spec/integration/rails_publish_spec.rb
+++ b/spec/integration/rails_publish_spec.rb
@@ -42,6 +42,14 @@ describe "publishing at least once" do
       expect(payload).to eq(expeted_payload)
     end
 
+    it 'publishes after touch' do
+      user = MMTestUser.create!(name: name)
+      expect(MultipleMan::Outbox.count).to eq(1)
+
+      user.touch
+      expect(MultipleMan::Outbox.count).to eq(2)
+    end
+
     it 'publishes payload when calling multiple_man_publish directly' do
       user = MMTestUser.create!(name: name)
       expect(MultipleMan::Outbox.count).to eq(1)


### PR DESCRIPTION
`.touch` does not trigger `after_update` lifecycle hooks, need
to explicitly add `after_touch` hook

https://apidock.com/rails/ActiveRecord/Persistence/touch