### PR TITLE
publish on update

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -40,11 +40,7 @@ module MultipleMan
 
     def self.add_in_commit_hooks(base)
       if base.respond_to?(:after_update)
-        base.after_update do |r|
-          if r.respond_to?(:changed?) && r.changed?
-            r.multiple_man_publish_outbox_true(:update)
-          end
-        end
+        base.after_update { |r| r.multiple_man_publish_outbox_true(:update) }
       end
 
       if base.respond_to?(:before_destroy)

--- a/spec/integration/rails_publish_spec.rb
+++ b/spec/integration/rails_publish_spec.rb
@@ -50,6 +50,14 @@ describe "publishing at least once" do
       expect(MultipleMan::Outbox.count).to eq(2)
     end
 
+    it 'publishes always publishes on update' do
+      user = MMTestUser.create!(name: name)
+      expect(MultipleMan::Outbox.count).to eq(1)
+
+      user.save
+      expect(MultipleMan::Outbox.count).to eq(2)
+    end
+
     it 'publishes payload when calling multiple_man_publish directly' do
       user = MMTestUser.create!(name: name)
       expect(MultipleMan::Outbox.count).to eq(1)


### PR DESCRIPTION
client code often expects a publish to occur when an
object is saved, sometimes failing to do that is misleading