### PR TITLE
publish associated records

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -39,20 +39,20 @@ module MultipleMan
     private
 
     def self.add_in_commit_hooks(base)
-      if base.respond_to?(:after_update)
-        base.after_update do |r|
-          if r.respond_to?(:changed?) && r.changed?
+      if base.respond_to?(:after_save)
+        base.after_save { |r|
+          return true unless r.respond_to?(:created_at) && r.respond_to?(:updated_at)
+
+          if r.created_at == r.updated_at
+            r.multiple_man_publish_outbox_true(:create)
+          else
             r.multiple_man_publish_outbox_true(:update)
           end
-        end
+        }
       end
 
       if base.respond_to?(:before_destroy)
         base.before_destroy { |r| r.multiple_man_publish_outbox_true(:destroy) }
-      end
-
-      if base.respond_to?(:after_create)
-        base.after_create { |r| r.multiple_man_publish_outbox_true(:create) }
       end
 
       if base.respond_to?(:after_touch)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,16 @@ def setup_db
       updated_at TIMESTAMP default NOW()
     )
   SQL
+
+  db.connection.execute <<~SQL
+    CREATE TABLE mm_test_profiles (
+      id              BIGSERIAL PRIMARY KEY,
+      mm_test_user_id BIGSERIAL,
+      name            varchar(255),
+      created_at      TIMESTAMP default NOW(),
+      updated_at      TIMESTAMP default NOW()
+    )
+  SQL
 end
 
 def setup_rails
@@ -76,6 +86,7 @@ def clear_db
   db.connection.drop_table :multiple_man_schema_info
   db.connection.drop_table :multiple_man_messages
   db.connection.drop_table :mm_test_users
+  db.connection.drop_table :mm_test_profiles
 end
 
 def wait_for(&block)


### PR DESCRIPTION
existing functionality publishes payload after persisting
the association tree, using `after_save` achieves this. This
is important when a MM message payload includes data from
associated records

callback order:

 1. record saved (on create)
 1. `after_create` callback fired
 1. association tree saved
 1. `after_save` callback fired

removing the `changed?` optimization, prefer getting the data guarantees
then worrying about optimization