### PR TITLE
class method publish

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -75,7 +75,14 @@ module MultipleMan
     module ClassMethods
 
       def multiple_man_publish(operation=:create)
-        multiple_man_publisher.publish(self, operation)
+        if MultipleMan.configuration.outbox_alpha?
+          multiple_man_publisher.publish(self, operation)
+          multiple_man_publisher.publish(self, operation, outbox: true)
+        elsif MultipleMan.configuration.at_least_once?
+          multiple_man_publisher.publish(self, operation, outbox: true)
+        else
+          multiple_man_publisher.publish(self, operation)
+        end
       end
 
       def publish(options = {})

--- a/spec/integration/rails_publish_spec.rb
+++ b/spec/integration/rails_publish_spec.rb
@@ -70,6 +70,14 @@ describe "publishing at least once" do
       expect(MultipleMan::Outbox.count).to eq(2)
     end
 
+    it 'publishes on class publish' do
+      user = MMTestUser.create!(name: name)
+      expect(MultipleMan::Outbox.count).to eq(1)
+
+      MMTestUser.multiple_man_publish
+      expect(MultipleMan::Outbox.count).to eq(2)
+    end
+
     it 'publishes payload when calling multiple_man_publish directly' do
       user = MMTestUser.create!(name: name)
       expect(MultipleMan::Outbox.count).to eq(1)

--- a/spec/mixins/publisher_spec.rb
+++ b/spec/mixins/publisher_spec.rb
@@ -39,10 +39,18 @@ describe MultipleMan::Publisher do
                                  .with(my_mock, :create, { outbox: false })
       my_mock.save
     end
+
+    it '#multiple_man_publish on class' do
+      expect(MockClass.multiple_man_publisher).to receive(:publish)
+        .with(MockClass, :create)
+
+      MockClass.multiple_man_publish
+    end
   end
 
   describe "publish at least once" do
     before {
+      setup_rails
       MultipleMan.configuration.messaging_mode = :at_least_once
       MockClass.publish
     }
@@ -55,10 +63,18 @@ describe MultipleMan::Publisher do
                                  .with(my_mock, :create, { outbox: true })
       my_mock.save
     end
+
+    it '#multiple_man_publish on class' do
+      expect(MockClass.multiple_man_publisher).to receive(:publish)
+        .with(MockClass, :create, { outbox: true })
+
+      MockClass.multiple_man_publish
+    end
   end
 
   describe "publish twice" do
     before {
+      setup_rails
       MultipleMan.configuration.messaging_mode = :outbox_alpha
       MockClass.publish
     }
@@ -74,6 +90,15 @@ describe MultipleMan::Publisher do
                                  .should_receive(:publish)
                                  .with(my_mock, :create, { outbox: true })
       my_mock.save
+    end
+
+    it '#multiple_man_publish on class' do
+      expect(MockClass.multiple_man_publisher).to receive(:publish)
+        .with(MockClass, :create)
+      expect(MockClass.multiple_man_publisher).to receive(:publish)
+        .with(MockClass, :create, { outbox: true })
+
+      MockClass.multiple_man_publish
     end
   end
 end


### PR DESCRIPTION
missed a case where calling `Record.multiple_man_publish` on
the class would not trigger a save to the outbox