### PR TITLE
outbox before danger

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -19,8 +19,8 @@ module MultipleMan
 
     def multiple_man_publish(operation=:create)
       if MultipleMan.configuration.outbox_alpha?
-        multiple_man_publish_outbox_false(operation)
         multiple_man_publish_outbox_true(operation)
+        multiple_man_publish_outbox_false(operation)
       elsif MultipleMan.configuration.at_least_once?
         multiple_man_publish_outbox_true(operation)
       else
@@ -76,8 +76,8 @@ module MultipleMan
 
       def multiple_man_publish(operation=:create)
         if MultipleMan.configuration.outbox_alpha?
-          multiple_man_publisher.publish(self, operation)
           multiple_man_publisher.publish(self, operation, outbox: true)
+          multiple_man_publisher.publish(self, operation)
         elsif MultipleMan.configuration.at_least_once?
           multiple_man_publisher.publish(self, operation, outbox: true)
         else


### PR DESCRIPTION
switch outbox publishing to be first, when in dual publish mode to prevent
a case where messages could appear dropped from the outbox

this can happen when calling `Record.multiple_man_publish` directly, the dangerous
message goes out before the outbox