### PR TITLE
published at uses insert time

### DIFF
--- a/lib/multiple_man/producers/general.rb
+++ b/lib/multiple_man/producers/general.rb
@@ -80,7 +80,7 @@ module MultipleMan
           message.values[:payload],
           routing_key: message.values[:routing_key],
           persistent:  true,
-          headers:     { published_at: Time.now.to_i }
+          headers:     { published_at: message.created_at.to_i }
         )
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,11 @@ def setup_rails
   ActiveRecord::Base.establish_connection(conn)
 end
 
+def insert_message(msg)
+  require_relative '../lib/multiple_man/outbox/message/sequel'
+  MultipleMan::Outbox::Message::Sequel.insert(msg)
+end
+
 def create_messages(count)
   require_relative '../lib/multiple_man/outbox/message/sequel'
 


### PR DESCRIPTION
published_at should use the time the record was inserted
into the outbox table, to give a better measure of total delay

using time the record was published to RMQ ignores time spent
waiting in the outbox table, potentially showing an incorrectly
low delay time