### PR TITLE
add guard for unchanged records in after_save

### DIFF
--- a/lib/multiple_man/mixins/publisher.rb
+++ b/lib/multiple_man/mixins/publisher.rb
@@ -41,9 +41,10 @@ module MultipleMan
     def self.add_in_commit_hooks(base)
       if base.respond_to?(:after_save)
         base.after_save { |r|
-          return true unless r.respond_to?(:created_at) && r.respond_to?(:updated_at)
-
-          if r.created_at == r.updated_at
+          if (r.respond_to?(:changed?) && !r.changed?) ||
+             (!r.respond_to?(:created_at) || !r.respond_to?(:updated_at))
+            # do nothing
+          elsif r.created_at == r.updated_at
             r.multiple_man_publish_outbox_true(:create)
           else
             r.multiple_man_publish_outbox_true(:update)

--- a/spec/integration/rails_publish_spec.rb
+++ b/spec/integration/rails_publish_spec.rb
@@ -127,6 +127,16 @@ describe "publishing at least once" do
       expect(MMTestUser.count).to eq(0)
       expect(MultipleMan::Outbox.count).to eq(0)
     end
+
+    it 'does not publish unchanged records' do
+      user = MMTestUser.create!(name: name)
+      user.save!
+
+      user = MMTestUser.find_by(name: name)
+      user.save!
+
+      expect(MultipleMan::Outbox.count).to eq(1)
+    end
   end
 
   context 'at most once' do


### PR DESCRIPTION
this is to help reduce the volume of messages sent through
the outbox