### PR TITLE
fetch by sets

### DIFF
--- a/lib/multiple_man/configuration.rb
+++ b/lib/multiple_man/configuration.rb
@@ -36,7 +36,7 @@ module MultipleMan
       self.messaging_mode = :at_most_once
       self.db_url = nil
       self.producer_sleep_timeout = 2
-      self.producer_batch_size = 1000
+      self.producer_batch_size = 100
       self.channel_reset_time = nil
 
       @subscriber_registry = Subscribers::Registry.new

--- a/lib/multiple_man/outbox/message/rails.rb
+++ b/lib/multiple_man/outbox/message/rails.rb
@@ -10,7 +10,8 @@ module MultipleMan
 
           new(
             payload:     data.payload,
-            routing_key: routing_key
+            routing_key: routing_key,
+            set_name:    MultipleMan::RoutingKey.model_name(routing_key)
           ).save!
         end
       end

--- a/lib/multiple_man/outbox/message/sequel.rb
+++ b/lib/multiple_man/outbox/message/sequel.rb
@@ -2,15 +2,29 @@ module MultipleMan
   module Outbox
     module Message
       class Sequel < ::Sequel::Model(Outbox::DB.connection[:multiple_man_messages])
-        def self.in_batches_and_delete(batch_size, &block)
-          total   = count
-          batches = (total / batch_size.to_f).ceil
-
-          batches.times do
-            messages = order(:id).limit(batch_size).to_a
+        def self.in_groups_and_delete(size = 100, &block)
+          messages = Outbox::DB.connection.fetch(grouped_by_limit_sql(size)).all
+          until messages.empty?
             yield(messages)
-            where(id: messages.map(&:id)).delete
+            where(id:
+              messages.map { |h| h[:id] }
+            ).delete
+            messages = Outbox::DB.connection.fetch(grouped_by_limit_sql(size)).all
           end
+        end
+
+        private
+
+        def self.grouped_by_limit_sql(size)
+          <<~SQL
+            select *
+            from (
+              select *, row_number() over (
+                partition by set_name order by id
+              ) as rownum from multiple_man_messages
+            ) msgs
+            where msgs.rownum <= #{size};
+          SQL
         end
       end
     end

--- a/lib/multiple_man/outbox/migrations/20182816141230_add_set_name.rb
+++ b/lib/multiple_man/outbox/migrations/20182816141230_add_set_name.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  change do
+    add_column :multiple_man_messages, :set_name, String, null: false
+    add_index :multiple_man_messages, :set_name
+  end
+end

--- a/spec/outbox/message/sequel_spec.rb
+++ b/spec/outbox/message/sequel_spec.rb
@@ -21,14 +21,14 @@ describe 'Outbox::Message::Sequel' do
     expect(subject.all.count).to eq(0)
   end
 
-  it '#in_batches yields messages' do
-    create_messages(4)
+  it '#in_groups yields messages ordered by set name' do
+    create_messages(40)
 
-    expected_ids = subject.all.map(&:id)
+    expected_ids = subject.order_by(:set_name, :id).all.map(&:id)
     result = []
 
-    subject.in_batches_and_delete(2) do |messages|
-      messages.each { |m| result << m.id }
+    subject.in_groups_and_delete do |messages|
+      messages.each { |m| result << m[:id] }
     end
 
     expect(subject.all.count).to eq(0)

--- a/spec/producers/general_spec.rb
+++ b/spec/producers/general_spec.rb
@@ -22,7 +22,8 @@ describe MultipleMan::Producers::General do
         routing_key: 'Foo.bar',
         payload:     'foo',
         created_at:  old_time,
-        updated_at:  old_time
+        updated_at:  old_time,
+        set_name:    'Foo'
       }
 
       MultipleMan.configuration.messaging_mode = :at_least_once

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,7 @@ def create_messages(count)
 end
 
 def listener_klasses
-  @routing_key ||= 3.times.map { |i| "User#{i}" }
+  @routing_key ||= 20.times.map { |i| "User#{i}" }
 end
 
 def routing_keys
@@ -73,11 +73,13 @@ def routing_keys
 end
 
 def sample_message(i)
+  routing_key = routing_keys.sample
   message = {
-    routing_key: routing_keys.sample,
+    routing_key: routing_key,
     payload:     { counter: i }.to_json,
     created_at:  Time.now,
-    updated_at:  Time.now
+    updated_at:  Time.now,
+    set_name:    MultipleMan::RoutingKey.model_name(routing_key)
   }
 end
 


### PR DESCRIPTION
The previous fetch method grabbed the x most recent messages from the stack,
then split them into groups for publishing. This would slow down
publishing when a large amount of a single record type was published,
fetching the top x could all be of the same type - leading to the splitting
into groups doing very little as well as blocking other records being published
while they are lower in the stack

Now we are grabbing the top x messages per set name, so large volume of a single
record type does not block other messages from being published in the stack

Batch size is now per group, so the total number of records fetched at any time
changes from 1000 to n*100 (default), where n is the number of models being published