### PR TITLE
outbox: reset publishing channel

### DIFF
--- a/lib/multiple_man/configuration.rb
+++ b/lib/multiple_man/configuration.rb
@@ -13,7 +13,8 @@ module MultipleMan
                   :worker_concurrency, :reraise_errors, :connection_recovery,
                   :queue_name, :prefetch_size, :bunny_opts, :exchange_opts,
                   :publisher_confirms, :messaging_mode, :db_url,
-                  :producer_sleep_timeout, :producer_batch_size
+                  :producer_sleep_timeout, :producer_batch_size,
+                  :channel_reset_time
 
     attr_writer :logger, :tracer
 
@@ -36,6 +37,7 @@ module MultipleMan
       self.db_url = nil
       self.producer_sleep_timeout = 2
       self.producer_batch_size = 1000
+      self.channel_reset_time = nil
 
       @subscriber_registry = Subscribers::Registry.new
     end

--- a/lib/multiple_man/connection.rb
+++ b/lib/multiple_man/connection.rb
@@ -77,6 +77,13 @@ module MultipleMan
       end
     end
 
+    def self.reset_channel!
+      @mutex.synchronize do
+        channel.close
+        Thread.current.thread_variable_set(:multiple_man_current_channel, nil)
+      end
+    end
+
     attr_reader :topic
     attr_accessor :channel
     delegate :queue, to: :channel

--- a/spec/producers/general_spec.rb
+++ b/spec/producers/general_spec.rb
@@ -67,5 +67,26 @@ describe MultipleMan::Producers::General do
       et = Time.now
       (et - st).should be >= MultipleMan.configuration.producer_sleep_timeout
     end
+
+    context 'channel_reset' do
+      after(:each) { MultipleMan.configuration.channel_reset_time = nil }
+
+      it 'does not reset channel' do
+        expect(subject).to receive(:loop).and_yield
+
+        create_messages(1)
+        expect(MultipleMan::Connection).to_not receive(:reset_channel!)
+        subject.run_producer
+      end
+
+      it 'resets channel' do
+        MultipleMan.configuration.channel_reset_time = 0
+        expect(subject).to receive(:loop).and_yield
+
+        create_messages(1)
+        expect(MultipleMan::Connection).to receive(:reset_channel!)
+        subject.run_producer
+      end
+    end
   end
 end


### PR DESCRIPTION
channel publish performance appears to degrade over time, resetting
the channel appears to fix the problem. On a sample app I measured
a decrease from ~280/s to ~220/s over an hour period (roughly the same
rate for longer periods of time)

I do not know what the root cause is (i.e. is this an issue with RMQ,
the ruby bunny library or something application level) resetting the
channel seems to fix it (keep publishing rate near max). This operation
is very cheap and quick so it is probably easier to reset every few minutes until
there is more time to investigate the root cause.