### PR TITLE
Outbox latency improvements

### DIFF
--- a/lib/multiple_man/outbox/message/rails.rb
+++ b/lib/multiple_man/outbox/message/rails.rb
@@ -14,6 +14,11 @@ module MultipleMan
             set_name:    MultipleMan::RoutingKey.model_name(routing_key)
           ).save!
         end
+
+        after_save do
+          # Notify the producer that there is a new message
+          self.class.connection.execute("NOTIFY outbox_channel")
+        end
       end
     end
   end

--- a/lib/multiple_man/outbox/message/sequel.rb
+++ b/lib/multiple_man/outbox/message/sequel.rb
@@ -14,6 +14,14 @@ module MultipleMan
           end
         end
 
+        def self.run_listener(producer_thread)
+          # This will run infinitely in the main thread
+          Outbox::DB.connection.listen('outbox_channel', { loop: true }) do |_channel, _notifier_pid, _payload|
+            # Wake the producer thread up if it's sleeping and a new message comes in
+            producer_thread.run if producer_thread.status == 'sleep'
+          end
+        end
+
         private
 
         def self.fetch_messages_from_database(size)

--- a/lib/multiple_man/producers/general.rb
+++ b/lib/multiple_man/producers/general.rb
@@ -11,6 +11,12 @@ module MultipleMan
         require_relative '../outbox/db'
         require_relative '../outbox/message/sequel'
 
+        @producer_thread = Thread.new { producer_loop }
+
+        Outbox::Message::Sequel.run_listener(@producer_thread)
+      end
+
+      def producer_loop
         last_run = Time.now
         loop do
           timeout(last_run) unless @did_work


### PR DESCRIPTION
This MR covers two main performance improvements:

1. Assume that if there was at least one record in the messages table last time, that there will be more this time. So, don't sleep and immediately try and get those message(s) from the db. If there were no messages in the table, sleep per usual until the next polling time.
This will mainly help when the table gets backed up with many messages, so we aren't waiting ~2 seconds to get the next set of data from the messages table.

2. To get around the delay associated with polling, I see only a few options.
* decrease the polling time until it is within an 'acceptable' range of delay. This can get extremely expensive if you're polling the db many times per second.
* somehow notify the MM Producer that there are more records and to check the messages table. 
** Obviously, if we do this through http, then we will synchronously couple each producer to the service, and could easily overwhelm the single producer given enough requests. It would also probably still be too delayed
** If we do this through rabbit, while it would be fast it would also still have the same problem of dropped messages. It would be very probably that < 100% of records are within our 'acceptable delay'.
** If we do this through Postgres (as is implemented here), we get 100% guarantee of delivery, though at the cost of performance. There will be increased load on the db using Postgres' NOTIFY/LISTEN however assuming we only have one listener, it shouldn't affect performance too much. There are few benchmarks online on the performance impact of NOTIFY/LISTEN in Postgres.

As is below, I implemented NOTIFY/LISTEN such that:
Listener thread will listen for notifications. When the listener thread receives one, it will wake the producer from sleep if it's not running. If it's already running, it will do nothing.
Producer thread will behave as usual, polling the db every 2 seconds unless its sleep is interrupted.
Every multiple_man_publish will now send a NOTIFY after saving to the multiple_man_messages table.